### PR TITLE
Introduce Comparator[T] — remove cmp.Ordered from all ordered collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ vendor/
 
 # Outros
 /graphify-out
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Every collection ships in two flavors: a fast, single-threaded core type and a `
 
 ## Features
 
-- **Generic collections.** `LinkedList`, `Queue`, `Deque`, `Stack`, `Heap`, `Set`, `BTreeSet`, `BTreeMap`, and `DAG`, all parameterized on `any` or `comparable`/`Ordered` as appropriate.
+- **Generic collections.** `LinkedList`, `Queue`, `Deque`, `Stack`, `Heap`, `Set`, `BTreeSet`, `BTreeMap`, and `DAG`, all parameterized on `any` or `comparable` as appropriate, with custom ordering via `comparator.Comparator`.
 - **Concurrency-ready.** Drop-in `SyncLinkedList`, `SyncQueue`, `SyncDeque`, `SyncStack`, `SyncHeap`, and `SyncSet` types for safe access from multiple goroutines.
-- **Lazy streams.** `Stream[T]` with a pipeline-style API — `Filter`, `Map`, `FlatMap`, `Distinct`, `Sorted`, `Limit`, `Skip`, `Concat`, `Peek` — plus terminal operations `ToSlice`, `ForEach`, `Count`, `Any`, `All`, `Reduce`, and `FindFirst`. Streams are single-pass and not goroutine-safe.
+- **Lazy streams.** `Stream[T]` with a pipeline-style API — `Filter`, `Map`, `FlatMap`, `Distinct`, `DistinctBy`, `SortedBy`, `Limit`, `Skip`, `Concat`, `Peek` — plus terminal operations `ToSlice`, `ForEach`, `Count`, `Any`, `All`, `Reduce`, and `FindFirst`. Streams are single-pass and not goroutine-safe.
 - **Optional.** `Optional[T]` is a type-safe container that makes absent values explicit — no nil, no sentinel. Supports `Of`, `OfPtr`, `OrElse`, `OrElseGet`, `IfPresent`, `Filter`, `Map`, and `FlatMap`.
 - **Bitmap-backed `EnumSet`.** O(1) membership, union, intersection, and difference for any type that exposes an `Index() int` method.
 - **Ordered trees.** B-Tree-backed `BTreeSet` and `BTreeMap` with sorted iteration, in-order range queries, min/max lookup, and a forward iterator.
@@ -106,7 +106,10 @@ fmt.Println(sl.String()) // [42]
 ### Stream
 
 ```go
-import "github.com/halissontorres/go-bag/pkg/stream"
+import (
+    "github.com/halissontorres/go-bag/pkg/comparator"
+    "github.com/halissontorres/go-bag/pkg/stream"
+)
 
 // Build a pipeline: double every number, keep only those > 10, take the first 3.
 result := stream.Limit(
@@ -133,8 +136,9 @@ close(ch)
 words := stream.FromChannel(ch).ToSlice() // ["a" "b" "c"]
 
 // Deduplicate and sort
-unique := stream.Sorted(
+unique := stream.SortedBy(
     stream.Distinct(stream.FromSlice([]int{3, 1, 2, 1, 3})),
+    comparator.Natural[int](),
 ).ToSlice() // [1 2 3]
 
 // Pre-size the internal buffer for large streams.
@@ -209,10 +213,13 @@ fmt.Println(empty)   // Optional[empty]
 ### Heap
 
 ```go
-import "github.com/halissontorres/go-bag/pkg/heap"
+import (
+    "github.com/halissontorres/go-bag/pkg/comparator"
+    "github.com/halissontorres/go-bag/pkg/heap"
+)
 
-// Works with any cmp.Ordered type: int, float64, string, …
-h := heap.New[int]()
+// Create a Min-Heap (default: natural ascending order).
+h := heap.New(comparator.Natural[int]())
 
 h.Push(50)
 h.Push(10)
@@ -230,36 +237,107 @@ v, _ = h.Pop()  // 10
 fmt.Println(h.Len()) // 3
 
 // Works with strings too — ordering is lexicographic.
-words := heap.New[string]()
+words := heap.New(comparator.Natural[string]())
 words.Push("Zebra")
 words.Push("Abacaxi")
 words.Push("Banana")
 first, _ := words.Pop() // "Abacaxi"
 
-// Pop and Peek return an error when the heap is empty.
-empty := heap.New[float64]()
-_, err := empty.Pop() // err: "empty heap"
-
-// Thread-safe variant — same API, protected by a sync.RWMutex.
-sh := heap.NewSync[int]()
-sh.Push(3)
-sh.Push(1)
-sh.Push(2)
-min, _ = sh.Pop() // 1
-
-// Functional options: Min-Heap (default), Max-Heap, or custom comparator.
-maxH := heap.New[int](heap.WithMaxHeap[int]())
+// Max-Heap: use Reverse.
+maxH := heap.New(comparator.Reverse[int]())
 maxH.Push(10); maxH.Push(30); maxH.Push(20)
 top, _ := maxH.Pop() // 30
 
-byLen := heap.New[string](heap.WithLessFunc(func(a, b string) bool {
+// Custom comparator: order by string length.
+byLen := heap.New(comparator.Comparator[string](func(a, b string) bool {
     return len(a) < len(b)
 }))
 byLen.Push("go"); byLen.Push("rust"); byLen.Push("c")
 shortest, _ := byLen.Pop() // "c"
+
+// Pop and Peek return an error when the heap is empty.
+empty := heap.New(comparator.Natural[float64]())
+_, err := empty.Pop() // err: "empty heap"
+
+// Thread-safe variant — same API, protected by a sync.RWMutex.
+sh := heap.NewSync(comparator.Natural[int]())
+sh.Push(3)
+sh.Push(1)
+sh.Push(2)
+min, _ = sh.Pop() // 1
 ```
 
-> **Note:** `Heap` defaults to a Min-Heap — `Pop` returns the smallest element. Use `WithMaxHeap` or `WithLessFunc` to change the ordering. Composite operations (e.g. peek-then-pop) are not atomic even on `SyncHeap`.
+> **Note:** `Heap` requires a `Comparator` to define ordering — use `comparator.Natural` for ascending or `comparator.Reverse` for descending. Composite operations (e.g. peek-then-pop) are not atomic even on `SyncHeap`.
+
+### Custom ordering with Comparator
+
+All ordered collections (`Heap`, `BTreeSet`, `BTreeMap`, and `Stream.SortedBy`) accept a `comparator.Comparator[T]` that defines element ordering. The `comparator` package provides built-in helpers and a chaining API for multi-criterion ordering.
+
+```go
+import "github.com/halissontorres/go-bag/pkg/comparator"
+```
+
+#### Built-in helpers
+
+```go
+// Natural ascending order for any cmp.Ordered type.
+cmp := comparator.Natural[int]()    // a < b
+rev := comparator.Reverse[int]()    // a > b (descending)
+
+// Extract a key from a struct for comparison.
+type Task struct {
+    Name     string
+    Priority int
+}
+byPriority := comparator.ByField(func(t Task) int { return t.Priority })
+byName     := comparator.ByField(func(t Task) string { return t.Name })
+```
+
+#### Multi-criterion ordering with Then
+
+```go
+// Priority descending, then name ascending.
+ordered := comparator.Reverse[int]().
+    Then(comparator.Natural[string]())
+
+// Applied to structs via ByField:
+byPriorityDesc := comparator.ByField(func(t Task) int { return -t.Priority })
+byPriorityThenName := byPriorityDesc.Then(byName)
+```
+
+#### Using Comparators with collections
+
+```go
+// Heap ordered by struct field.
+taskHeap := heap.New(comparator.ByField(func(t Task) int { return t.Priority }))
+taskHeap.Push(Task{"write docs", 3})
+taskHeap.Push(Task{"fix bug", 1})
+
+// BTreeSet with multi-criterion ordering.
+set := tree.NewBTreeSet(
+    comparator.ByField(func(t Task) int { return t.Priority }).
+        Then(comparator.ByField(func(t Task) string { return t.Name })),
+)
+
+// BTreeMap with struct keys ordered by name.
+m := tree.NewBTreeMap[Task, string](
+    comparator.ByField(func(t Task) string { return t.Name }),
+)
+m.Put(Task{"fix bug", 1}, "open")
+
+// Stream sorted by priority, then by name.
+stream.SortedBy(stream.FromSlice(tasks), byPriority.Then(byName))
+```
+
+#### External types (time.Time, net.IP)
+
+```go
+eventHeap := heap.New(comparator.Comparator[time.Time](
+    func(a, b time.Time) bool { return a.Before(b) },
+))
+```
+
+> **Note:** The `Comparator` must be **consistent** — if `cmp(a,b)` is true, then `cmp(b,a)` must be false. Two elements are considered equal when neither `cmp(a,b)` nor `cmp(b,a)` is true.
 
 ### Queue
 
@@ -449,10 +527,12 @@ fmt.Println(es.String())   // {0}
 ### BTreeSet
 
 ```go
-import "github.com/halissontorres/go-bag/pkg/tree"
+import (
+    "github.com/halissontorres/go-bag/pkg/comparator"
+    "github.com/halissontorres/go-bag/pkg/tree"
+)
 
-// Works with any cmp.Ordered type: int, float64, string, …
-s := tree.NewBTreeSet[int]()
+s := tree.NewBTreeSet(comparator.Natural[int]())
 s.Add(5)
 s.Add(3)
 s.Add(8)
@@ -486,16 +566,19 @@ fmt.Println(s.Elements()) // [1 5 8]
 // Custom minimum degree via functional option (controls tree fanout).
 // Each node holds between t-1 and 2t-1 keys; higher values reduce height
 // but increase per-node memory usage.
-large := tree.NewBTreeSet[string](tree.WithMinDegree(16))
+large := tree.NewBTreeSet(comparator.Natural[string](), tree.WithMinDegree(16))
 _ = large
 ```
 
 ### BTreeMap
 
 ```go
-import "github.com/halissontorres/go-bag/pkg/tree"
+import (
+    "github.com/halissontorres/go-bag/pkg/comparator"
+    "github.com/halissontorres/go-bag/pkg/tree"
+)
 
-m := tree.NewBTreeMap[string, int]()
+m := tree.NewBTreeMap[string, int](comparator.Natural[string]())
 m.Put("banana", 2)
 m.Put("apple", 5)
 m.Put("cherry", 1)
@@ -529,7 +612,7 @@ m.Remove("banana")
 fmt.Println(m.Len()) // 2
 
 // Custom minimum degree via functional option.
-wide := tree.NewBTreeMap[int, string](tree.WithMinDegree(8))
+wide := tree.NewBTreeMap[int, string](comparator.Natural[int](), tree.WithMinDegree(8))
 _ = wide
 ```
 
@@ -680,9 +763,10 @@ go test -bench=. -benchmem ./...
 ```
 go-bag/
 ├── pkg/
+│   ├── comparator/ # Comparator[T] — custom ordering
 │   ├── enum/    # Enum code generator (Generate, EnumInfo)
 │   ├── graph/   # DAG — directed acyclic graph
-│   ├── heap/    # Heap, SyncHeap (min-heap)
+│   ├── heap/    # Heap, SyncHeap (priority queue)
 │   ├── list/    # LinkedList, SyncLinkedList
 │   ├── opt/     # Optional[T]
 │   ├── queue/   # Queue, SyncQueue, Deque, SyncDeque

--- a/pkg/comparator/comparator.go
+++ b/pkg/comparator/comparator.go
@@ -1,0 +1,39 @@
+package comparator
+
+import gocmp "cmp"
+
+// Comparator defines the ordering between two elements of the same type.
+// Returns true if a should come before b.
+type Comparator[T any] func(a, b T) bool
+
+// Natural returns a Comparator that uses the natural ascending ordering
+// for types that satisfy cmp.Ordered.
+func Natural[T gocmp.Ordered]() Comparator[T] {
+	return func(a, b T) bool { return a < b }
+}
+
+// Reverse returns a Comparator that uses the natural descending ordering
+// for types that satisfy cmp.Ordered.
+func Reverse[T gocmp.Ordered]() Comparator[T] {
+	return func(a, b T) bool { return a > b }
+}
+
+// ByField returns a Comparator derived from a key extraction function.
+// Useful for ordering structs by a specific field.
+func ByField[T any, K gocmp.Ordered](key func(T) K) Comparator[T] {
+	return func(a, b T) bool { return key(a) < key(b) }
+}
+
+// Then chains two Comparators: uses secondary when primary considers
+// a and b equal (neither a < b nor b < a).
+func (c Comparator[T]) Then(secondary Comparator[T]) Comparator[T] {
+	return func(a, b T) bool {
+		if c(a, b) {
+			return true
+		}
+		if c(b, a) {
+			return false
+		}
+		return secondary(a, b)
+	}
+}

--- a/pkg/comparator/comparator_test.go
+++ b/pkg/comparator/comparator_test.go
@@ -1,0 +1,127 @@
+package comparator_test
+
+import (
+	"testing"
+
+	"github.com/halissontorres/go-bag/pkg/comparator"
+)
+
+type person struct {
+	Name string
+	Age  int
+}
+
+func TestNaturalInt(t *testing.T) {
+	cmp := comparator.Natural[int]()
+	if !cmp(1, 2) {
+		t.Error("Natural[int]: 1 should come before 2")
+	}
+	if cmp(2, 1) {
+		t.Error("Natural[int]: 2 should not come before 1")
+	}
+	if cmp(1, 1) {
+		t.Error("Natural[int]: 1 should not come before 1")
+	}
+}
+
+func TestNaturalString(t *testing.T) {
+	cmp := comparator.Natural[string]()
+	if !cmp("a", "b") {
+		t.Error(`Natural[string]: "a" should come before "b"`)
+	}
+	if cmp("b", "a") {
+		t.Error(`Natural[string]: "b" should not come before "a"`)
+	}
+	if cmp("a", "a") {
+		t.Error(`Natural[string]: "a" should not come before "a"`)
+	}
+}
+
+func TestReverseInt(t *testing.T) {
+	cmp := comparator.Reverse[int]()
+	if !cmp(2, 1) {
+		t.Error("Reverse[int]: 2 should come before 1 (descending)")
+	}
+	if cmp(1, 2) {
+		t.Error("Reverse[int]: 1 should not come before 2 (descending)")
+	}
+	if cmp(1, 1) {
+		t.Error("Reverse[int]: 1 should not come before 1")
+	}
+}
+
+func TestByFieldName(t *testing.T) {
+	cmp := comparator.ByField(func(p person) string { return p.Name })
+
+	alice := person{Name: "Alice", Age: 30}
+	bob := person{Name: "Bob", Age: 25}
+
+	if !cmp(alice, bob) {
+		t.Error("ByField[Name]: Alice should come before Bob")
+	}
+	if cmp(bob, alice) {
+		t.Error("ByField[Name]: Bob should not come before Alice")
+	}
+}
+
+func TestByFieldAge(t *testing.T) {
+	cmp := comparator.ByField(func(p person) int { return p.Age })
+
+	young := person{Name: "Alice", Age: 25}
+	old := person{Name: "Bob", Age: 30}
+
+	if !cmp(young, old) {
+		t.Error("ByField[Age]: 25 should come before 30")
+	}
+	if cmp(old, young) {
+		t.Error("ByField[Age]: 30 should not come before 25")
+	}
+}
+
+func TestThenPrimaryDecides(t *testing.T) {
+	byAge := comparator.ByField(func(p person) int { return p.Age })
+	byName := comparator.ByField(func(p person) string { return p.Name })
+	combined := byAge.Then(byName)
+
+	young := person{Name: "Zoe", Age: 25}
+	old := person{Name: "Alice", Age: 30}
+
+	if !combined(young, old) {
+		t.Error("Then: primary (age) should decide when ages differ; 25 < 30")
+	}
+	if combined(old, young) {
+		t.Error("Then: 30 should not come before 25 when primary is age")
+	}
+}
+
+func TestThenFallbackToSecondary(t *testing.T) {
+	byAge := comparator.ByField(func(p person) int { return p.Age })
+	byName := comparator.ByField(func(p person) string { return p.Name })
+	combined := byAge.Then(byName)
+
+	alice := person{Name: "Alice", Age: 30}
+	bob := person{Name: "Bob", Age: 30}
+
+	if !combined(alice, bob) {
+		t.Error("Then: secondary (name) should decide when ages are equal; Alice < Bob")
+	}
+	if combined(bob, alice) {
+		t.Error("Then: Bob should not come before Alice when ages are equal")
+	}
+}
+
+func TestThenAllEqual(t *testing.T) {
+	byAge := comparator.ByField(func(p person) int { return p.Age })
+	byName := comparator.ByField(func(p person) string { return p.Name })
+	combined := byAge.Then(byName)
+
+	a1 := person{Name: "Alice", Age: 30}
+	a2 := person{Name: "Alice", Age: 30}
+
+	if combined(a1, a2) {
+		t.Error("Then: equal elements should not be ordered either way")
+	}
+	if combined(a2, a1) {
+		t.Error("Then: equal elements should not be ordered either way")
+	}
+}

--- a/pkg/heap/heap.go
+++ b/pkg/heap/heap.go
@@ -1,16 +1,17 @@
 package heap
 
 import (
-	"cmp"
 	"container/heap"
 	"errors"
 	"sync"
+
+	"github.com/halissontorres/go-bag/pkg/comparator"
 )
 
 // internalHeap implements heap.Interface.
-type internalHeap[T cmp.Ordered] struct {
+type internalHeap[T any] struct {
 	data []T
-	less func(a, b T) bool
+	less comparator.Comparator[T]
 }
 
 func (h *internalHeap[T]) Len() int           { return len(h.data) }
@@ -28,14 +29,15 @@ func (h *internalHeap[T]) Pop() any {
 }
 
 // Heap represents a generic Priority Queue.
-type Heap[T cmp.Ordered] struct {
+type Heap[T any] struct {
 	data *internalHeap[T]
 }
 
-// New cria um Heap. Padrão: Min-Heap.
-func New[T cmp.Ordered](opts ...HeapOption[T]) *Heap[T] {
+// New creates a Heap ordered by the provided Comparator.
+// The comparator is mandatory — there is no default ordering.
+func New[T any](cmp comparator.Comparator[T], opts ...HeapOption[T]) *Heap[T] {
 	h := &internalHeap[T]{
-		less: func(a, b T) bool { return a < b }, // padrão Min-Heap
+		less: cmp,
 	}
 	for _, o := range opts {
 		o(h)
@@ -67,14 +69,15 @@ func (h *Heap[T]) Peek() (T, error) {
 func (h *Heap[T]) Len() int      { return h.data.Len() }
 func (h *Heap[T]) IsEmpty() bool { return h.data.Len() == 0 }
 
-// SyncHeap é uma Heap thread-safe.
-type SyncHeap[T cmp.Ordered] struct {
+// SyncHeap is a thread-safe Heap.
+type SyncHeap[T any] struct {
 	mu sync.RWMutex
 	h  *Heap[T]
 }
 
-func NewSync[T cmp.Ordered](opts ...HeapOption[T]) *SyncHeap[T] {
-	return &SyncHeap[T]{h: New[T](opts...)}
+// NewSync creates a thread-safe Heap ordered by the provided Comparator.
+func NewSync[T any](cmp comparator.Comparator[T], opts ...HeapOption[T]) *SyncHeap[T] {
+	return &SyncHeap[T]{h: New[T](cmp, opts...)}
 }
 
 func (sh *SyncHeap[T]) Push(v T) {

--- a/pkg/heap/heap_test.go
+++ b/pkg/heap/heap_test.go
@@ -4,10 +4,12 @@ import (
 	"math/rand"
 	"sync"
 	"testing"
+
+	"github.com/halissontorres/go-bag/pkg/comparator"
 )
 
 func TestHeap_Int_MinHeapBehavior(t *testing.T) {
-	h := New[int]() // padrão: Min-Heap
+	h := New(comparator.Natural[int]())
 
 	if h.Len() != 0 {
 		t.Errorf("expected Len 0, got %d", h.Len())
@@ -44,14 +46,13 @@ func TestHeap_Int_MinHeapBehavior(t *testing.T) {
 }
 
 func TestHeap_String_Ordering(t *testing.T) {
-	h := New[string]()
+	h := New(comparator.Natural[string]())
 
 	h.Push("Zebra")
 	h.Push("Abacaxi")
 	h.Push("Maçã")
 	h.Push("Banana")
 
-	// The smallest element (alphabetical order) should be "Abacaxi"
 	val, err := h.Pop()
 	if err != nil {
 		t.Fatalf("unexpected error in Pop: %v", err)
@@ -60,7 +61,6 @@ func TestHeap_String_Ordering(t *testing.T) {
 		t.Errorf("expected 'Abacaxi', got '%s'", val)
 	}
 
-	// The next one should be "Banana"
 	val, _ = h.Pop()
 	if val != "Banana" {
 		t.Errorf("expected 'Banana', got '%s'", val)
@@ -68,15 +68,13 @@ func TestHeap_String_Ordering(t *testing.T) {
 }
 
 func TestHeap_EmptyErrors(t *testing.T) {
-	h := New[float64]()
+	h := New(comparator.Natural[float64]())
 
-	// Test Peek on empty Heap
 	_, err := h.Peek()
 	if err == nil {
 		t.Error("expected error when Peek on empty heap, but none occurred")
 	}
 
-	// Test Pop on empty Heap
 	_, err = h.Pop()
 	if err == nil {
 		t.Error("expected error when Pop on empty heap, but none occurred")
@@ -84,7 +82,7 @@ func TestHeap_EmptyErrors(t *testing.T) {
 }
 
 func TestSyncHeap_EmptyErrors(t *testing.T) {
-	h := NewSync[float64]()
+	h := NewSync(comparator.Natural[float64]())
 
 	_, err := h.Peek()
 	if err == nil {
@@ -101,10 +99,9 @@ func TestSyncHeap_ConcurrentPushPop(t *testing.T) {
 	const goroutines = 10
 	const itemsEach = 100
 
-	h := NewSync[int]()
+	h := NewSync(comparator.Natural[int]())
 	var wg sync.WaitGroup
 
-	// Concurrent pushes
 	wg.Add(goroutines)
 	for g := 0; g < goroutines; g++ {
 		go func(base int) {
@@ -120,7 +117,6 @@ func TestSyncHeap_ConcurrentPushPop(t *testing.T) {
 		t.Errorf("expected %d elements, got %d", goroutines*itemsEach, h.Len())
 	}
 
-	// Concurrent pops
 	results := make(chan int, goroutines*itemsEach)
 	wg.Add(goroutines)
 	for g := 0; g < goroutines; g++ {
@@ -153,7 +149,7 @@ func TestSyncHeap_ConcurrentPushPop(t *testing.T) {
 }
 
 func TestSyncHeap_ConcurrentPeek(t *testing.T) {
-	h := NewSync[int]()
+	h := NewSync(comparator.Natural[int]())
 	for i := 100; i >= 1; i-- {
 		h.Push(i)
 	}
@@ -176,53 +172,8 @@ func TestSyncHeap_ConcurrentPeek(t *testing.T) {
 	wg.Wait()
 }
 
-// BenchmarkPush_Sequential tests the worst case/best case depending on Min/Max heap,
-// since numbers are already inserted in order.
-func BenchmarkHeap_PushSequential(b *testing.B) {
-	h := New[int]()
-	b.ResetTimer() // Reset timer to ignore the initialization above
-
-	for i := 0; i < b.N; i++ {
-		h.Push(i)
-	}
-}
-
-// BenchmarkPush_Random tests the most realistic scenario, inserting completely
-// random values, forcing up-heap at various tree levels.
-func BenchmarkHeap_PushRandom(b *testing.B) {
-	// Pre-generate numbers to ignore rand time in the benchmark
-	nums := make([]int, b.N)
-	for i := 0; i < b.N; i++ {
-		nums[i] = rand.Intn(1000000)
-	}
-
-	h := New[int]()
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		h.Push(nums[i])
-	}
-}
-
-// BenchmarkPop measures removal time. As Pop requires the Heap
-// to have elements, we fill it before starting the timer.
-func BenchmarkHeap_Pop(b *testing.B) {
-	h := New[int]()
-
-	// Setup: fill the Heap with b.N elements
-	for i := 0; i < b.N; i++ {
-		h.Push(rand.Intn(1000000))
-	}
-
-	b.ResetTimer() // Start measuring real time only for Pop
-
-	for i := 0; i < b.N; i++ {
-		_, _ = h.Pop()
-	}
-}
-
-func TestHeap_Int_MaxHeapBehavior(t *testing.T) {
-	h := New[int](WithMaxHeap[int]())
+func TestHeap_MaxHeapBehavior(t *testing.T) {
+	h := New(comparator.Reverse[int]())
 
 	h.Push(50)
 	h.Push(10)
@@ -250,16 +201,15 @@ func TestHeap_Int_MaxHeapBehavior(t *testing.T) {
 	}
 }
 
-func TestHeap_WithLessFunc(t *testing.T) {
-	// ordena pelo último dígito
-	h := New[int](WithLessFunc(func(a, b int) bool {
+func TestHeap_CustomComparator(t *testing.T) {
+	h := New(comparator.Comparator[int](func(a, b int) bool {
 		return a%10 < b%10
 	}))
 
-	h.Push(21) // último dígito: 1
-	h.Push(35) // último dígito: 5
-	h.Push(43) // último dígito: 3
-	h.Push(59) // último dígito: 9
+	h.Push(21) // last digit: 1
+	h.Push(35) // last digit: 5
+	h.Push(43) // last digit: 3
+	h.Push(59) // last digit: 9
 
 	first, err := h.Peek()
 	if err != nil {
@@ -279,27 +229,92 @@ func TestHeap_WithLessFunc(t *testing.T) {
 	}
 }
 
-func TestHeap_WithMinHeap_Explicit(t *testing.T) {
-	// WithMinHeap explícito deve se comportar igual ao padrão
-	h := New[int](WithMinHeap[int]())
+type task struct {
+	name     string
+	priority int
+}
 
-	h.Push(20)
-	h.Push(3)
-	h.Push(15)
+func TestHeap_StructByField(t *testing.T) {
+	h := New(comparator.ByField(func(t task) int { return t.priority }))
 
-	val, err := h.Pop()
+	h.Push(task{name: "low", priority: 50})
+	h.Push(task{name: "critical", priority: 1})
+	h.Push(task{name: "medium", priority: 30})
+
+	first, err := h.Pop()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if val != 3 {
-		t.Errorf("expected 3, got %d", val)
+	if first.priority != 1 || first.name != "critical" {
+		t.Errorf("expected {critical 1}, got {%s %d}", first.name, first.priority)
+	}
+
+	second, _ := h.Pop()
+	if second.priority != 30 {
+		t.Errorf("expected priority 30, got %d", second.priority)
+	}
+
+	third, _ := h.Pop()
+	if third.priority != 50 {
+		t.Errorf("expected priority 50, got %d", third.priority)
 	}
 }
 
-// --- Testes existentes sem alteração ---
+func TestHeap_StructMultiCriterion(t *testing.T) {
+	byPriority := comparator.ByField(func(t task) int { return t.priority })
+	byName := comparator.ByField(func(t task) string { return t.name })
+	cmp := byPriority.Then(byName)
+
+	h := New(cmp)
+
+	h.Push(task{name: "B", priority: 1})
+	h.Push(task{name: "A", priority: 1})
+	h.Push(task{name: "C", priority: 0})
+
+	first, _ := h.Pop()
+	if first.priority != 0 || first.name != "C" {
+		t.Errorf("expected {C 0}, got {%s %d}", first.name, first.priority)
+	}
+
+	second, _ := h.Pop()
+	if second.priority != 1 || second.name != "A" {
+		t.Errorf("expected {A 1}, got {%s %d}", second.name, second.priority)
+	}
+
+	third, _ := h.Pop()
+	if third.priority != 1 || third.name != "B" {
+		t.Errorf("expected {B 1}, got {%s %d}", third.name, third.priority)
+	}
+}
+
+func TestSyncHeap_Reverse(t *testing.T) {
+	h := NewSync(comparator.Reverse[int]())
+
+	h.Push(10)
+	h.Push(50)
+	h.Push(30)
+
+	first, err := h.Pop()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if first != 50 {
+		t.Errorf("expected 50, got %d", first)
+	}
+
+	second, _ := h.Pop()
+	if second != 30 {
+		t.Errorf("expected 30, got %d", second)
+	}
+
+	third, _ := h.Pop()
+	if third != 10 {
+		t.Errorf("expected 10, got %d", third)
+	}
+}
 
 func TestSyncHeap_MinHeapBehavior(t *testing.T) {
-	h := NewSync[int]()
+	h := NewSync(comparator.Natural[int]())
 
 	if !h.IsEmpty() {
 		t.Fatal("expected empty heap")
@@ -342,7 +357,7 @@ func TestSyncHeap_MinHeapBehavior(t *testing.T) {
 }
 
 func TestSyncHeap_MaxHeapBehavior(t *testing.T) {
-	h := NewSync[int](WithMaxHeap[int]())
+	h := NewSync(comparator.Reverse[int]())
 
 	h.Push(50)
 	h.Push(10)
@@ -369,10 +384,46 @@ func TestSyncHeap_MaxHeapBehavior(t *testing.T) {
 	}
 }
 
-// Benchmark comparativo Min vs Max para evidenciar que o custo é idêntico
+func BenchmarkHeap_PushSequential(b *testing.B) {
+	h := New(comparator.Natural[int]())
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		h.Push(i)
+	}
+}
+
+func BenchmarkHeap_PushRandom(b *testing.B) {
+	nums := make([]int, b.N)
+	for i := 0; i < b.N; i++ {
+		nums[i] = rand.Intn(1000000)
+	}
+
+	h := New(comparator.Natural[int]())
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		h.Push(nums[i])
+	}
+}
+
+func BenchmarkHeap_Pop(b *testing.B) {
+	h := New(comparator.Natural[int]())
+
+	for i := 0; i < b.N; i++ {
+		h.Push(rand.Intn(1000000))
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, _ = h.Pop()
+	}
+}
+
 func BenchmarkHeap_MinVsMax(b *testing.B) {
 	b.Run("MinHeap", func(b *testing.B) {
-		h := New[int](WithMinHeap[int]())
+		h := New(comparator.Natural[int]())
 		for i := 0; i < b.N; i++ {
 			h.Push(rand.Intn(1000000))
 		}
@@ -383,7 +434,7 @@ func BenchmarkHeap_MinVsMax(b *testing.B) {
 	})
 
 	b.Run("MaxHeap", func(b *testing.B) {
-		h := New[int](WithMaxHeap[int]())
+		h := New(comparator.Reverse[int]())
 		for i := 0; i < b.N; i++ {
 			h.Push(rand.Intn(1000000))
 		}

--- a/pkg/heap/options.go
+++ b/pkg/heap/options.go
@@ -1,24 +1,13 @@
 package heap
 
-import "cmp"
+import "github.com/halissontorres/go-bag/pkg/comparator"
 
-// HeapOption configura um Heap na criação.
-type HeapOption[T cmp.Ordered] func(*internalHeap[T])
+// HeapOption configures a Heap at creation time.
+type HeapOption[T any] func(*internalHeap[T])
 
-func WithMinHeap[T cmp.Ordered]() HeapOption[T] {
+// WithComparator overrides the comparator set at construction time.
+func WithComparator[T any](cmp comparator.Comparator[T]) HeapOption[T] {
 	return func(h *internalHeap[T]) {
-		h.less = func(a, b T) bool { return a < b }
-	}
-}
-
-func WithMaxHeap[T cmp.Ordered]() HeapOption[T] {
-	return func(h *internalHeap[T]) {
-		h.less = func(a, b T) bool { return a > b }
-	}
-}
-
-func WithLessFunc[T cmp.Ordered](less func(a, b T) bool) HeapOption[T] {
-	return func(h *internalHeap[T]) {
-		h.less = less
+		h.less = cmp
 	}
 }

--- a/pkg/stream/stream_ops.go
+++ b/pkg/stream/stream_ops.go
@@ -1,8 +1,9 @@
 package stream
 
 import (
-	"cmp"
 	"slices"
+
+	"github.com/halissontorres/go-bag/pkg/comparator"
 )
 
 // Filter returns a Stream containing only elements that satisfy the predicate.
@@ -76,13 +77,48 @@ func Distinct[T comparable](s *Stream[T], opts ...Option) *Stream[T] {
 	})
 }
 
-// Sorted collects all elements, sorts them, and emits them in order.
-// Accepts an optional WithInitialCap passed through to ToSlice.
-// Requires cmp.Ordered.
-func Sorted[T cmp.Ordered](s *Stream[T], opts ...Option) *Stream[T] {
+// SortedBy collects all elements, sorts them using the provided Comparator,
+// and emits them in order. Works with any type T.
+func SortedBy[T any](s *Stream[T], less comparator.Comparator[T], opts ...Option) *Stream[T] {
 	collected := s.ToSlice(opts...)
-	slices.Sort(collected)
+	slices.SortFunc(collected, func(a, b T) int {
+		if less(a, b) {
+			return -1
+		}
+		if less(b, a) {
+			return 1
+		}
+		return 0
+	})
 	return FromSlice(collected)
+}
+
+// DistinctBy eliminates duplicates using the Comparator for equality.
+// Two elements are considered equal when neither less(a,b) nor less(b,a) is true.
+// Use when T is not comparable or when equality is defined by ordering.
+func DistinctBy[T any](s *Stream[T], less comparator.Comparator[T], opts ...Option) *Stream[T] {
+	c := applyStreamOptions(opts)
+	seen := make([]T, 0, c.initialCap)
+	return NewStream(func() (T, bool) {
+		for {
+			val, ok := s.next()
+			if !ok {
+				var zero T
+				return zero, false
+			}
+			found := false
+			for _, v := range seen {
+				if !less(val, v) && !less(v, val) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				seen = append(seen, val)
+				return val, true
+			}
+		}
+	})
 }
 
 // Limit limits the number of elements emitted.

--- a/pkg/stream/stream_test.go
+++ b/pkg/stream/stream_test.go
@@ -4,6 +4,8 @@ import (
 	"math/rand"
 	"reflect"
 	"testing"
+
+	"github.com/halissontorres/go-bag/pkg/comparator"
 )
 
 func TestFromChannel(t *testing.T) {
@@ -120,7 +122,7 @@ func TestDistinct(t *testing.T) {
 func TestSorted(t *testing.T) {
 	input := []int{3, 1, 4, 1, 5, 9, 2}
 	s := FromSlice(input)
-	result := Sorted(s).ToSlice()
+	result := SortedBy(s, comparator.Natural[int]()).ToSlice()
 
 	expected := []int{1, 1, 2, 3, 4, 5, 9}
 	if !reflect.DeepEqual(expected, result) {
@@ -323,7 +325,7 @@ func BenchmarkSorted(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		s := FromSlice(input)
-		result := Sorted(s).ToSlice()
+		result := SortedBy(s, comparator.Natural[int]()).ToSlice()
 		_ = result
 	}
 }
@@ -387,7 +389,7 @@ func BenchmarkSortedAlreadySorted(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		s := FromSlice(input)
-		_ = Sorted(s).ToSlice()
+		_ = SortedBy(s, comparator.Natural[int]()).ToSlice()
 	}
 }
 
@@ -426,7 +428,7 @@ func TestDistinct_WithInitialCap(t *testing.T) {
 
 func TestSorted_WithInitialCap(t *testing.T) {
 	input := []int{3, 1, 4, 1, 5, 9, 2}
-	result := Sorted(FromSlice(input), WithInitialCap(len(input))).ToSlice()
+	result := SortedBy(FromSlice(input), comparator.Natural[int](), WithInitialCap(len(input))).ToSlice()
 	expected := []int{1, 1, 2, 3, 4, 5, 9}
 	if !reflect.DeepEqual(expected, result) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -435,7 +437,7 @@ func TestSorted_WithInitialCap(t *testing.T) {
 
 func TestSorted_WithInitialCap_Zero_Ignored(t *testing.T) {
 	input := []int{5, 3, 1}
-	result := Sorted(FromSlice(input), WithInitialCap(0)).ToSlice()
+	result := SortedBy(FromSlice(input), comparator.Natural[int](), WithInitialCap(0)).ToSlice()
 	expected := []int{1, 3, 5}
 	if !reflect.DeepEqual(expected, result) {
 		t.Errorf("Expected %v, got %v", expected, result)
@@ -462,7 +464,7 @@ func BenchmarkSortedLarge(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		s := FromSlice(input)
-		_ = Sorted(s).ToSlice()
+		_ = SortedBy(s, comparator.Natural[int]()).ToSlice()
 	}
 }
 
@@ -549,14 +551,88 @@ func BenchmarkSorted_InitialCap(b *testing.B) {
 	b.Run("DefaultCap", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			_ = Sorted(FromSlice(input)).ToSlice()
+			_ = SortedBy(FromSlice(input), comparator.Natural[int]()).ToSlice()
 		}
 	})
 
 	b.Run("WithInitialCap", func(b *testing.B) {
 		b.ReportAllocs()
 		for i := 0; i < b.N; i++ {
-			_ = Sorted(FromSlice(input), WithInitialCap(N)).ToSlice()
+			_ = SortedBy(FromSlice(input), comparator.Natural[int](), WithInitialCap(N)).ToSlice()
+		}
+	})
+}
+
+type task struct {
+	name     string
+	priority int
+}
+
+func TestSortedBy_StructByField(t *testing.T) {
+	tasks := []task{
+		{name: "low", priority: 50},
+		{name: "critical", priority: 1},
+		{name: "medium", priority: 30},
+	}
+	result := SortedBy(FromSlice(tasks), comparator.ByField(func(t task) int { return t.priority })).ToSlice()
+
+	if result[0].priority != 1 || result[1].priority != 30 || result[2].priority != 50 {
+		t.Errorf("tasks not sorted by priority: %v", result)
+	}
+}
+
+func TestSortedBy_StructMultiCriterion(t *testing.T) {
+	tasks := []task{
+		{name: "B", priority: 1},
+		{name: "A", priority: 1},
+		{name: "C", priority: 0},
+	}
+	byPriority := comparator.ByField(func(t task) int { return t.priority })
+	byName := comparator.ByField(func(t task) string { return t.name })
+	cmp := byPriority.Then(byName)
+
+	result := SortedBy(FromSlice(tasks), cmp).ToSlice()
+
+	if result[0].name != "C" || result[1].name != "A" || result[2].name != "B" {
+		t.Errorf("tasks not sorted by priority then name: %v", result)
+	}
+}
+
+func TestDistinctBy(t *testing.T) {
+	tasks := []task{
+		{name: "A", priority: 10},
+		{name: "B", priority: 10},
+		{name: "C", priority: 20},
+		{name: "D", priority: 10},
+	}
+	result := DistinctBy(FromSlice(tasks), comparator.ByField(func(t task) int { return t.priority })).ToSlice()
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 distinct elements, got %d: %v", len(result), result)
+	}
+	if result[0].name != "A" || result[1].name != "C" {
+		t.Errorf("unexpected distinct result: %v", result)
+	}
+}
+
+func BenchmarkSortedBy_InitialCap(b *testing.B) {
+	const N = 10000
+	input := make([]int, N)
+	for i := range input {
+		input[i] = rand.Intn(N)
+	}
+
+	b.Run("DefaultCap", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = SortedBy(FromSlice(input), comparator.Natural[int]()).ToSlice()
+		}
+	})
+
+	b.Run("WithInitialCap", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = SortedBy(FromSlice(input), comparator.Natural[int](), WithInitialCap(N)).ToSlice()
 		}
 	})
 }

--- a/pkg/tree/btree.go
+++ b/pkg/tree/btree.go
@@ -1,17 +1,17 @@
 package tree
 
-import "cmp"
+import "github.com/halissontorres/go-bag/pkg/comparator"
 
 const defaultMinDegree = 2 // minimum number of children (t)
 
 // bnode represents a node of the B-Tree.
-type bnode[K cmp.Ordered] struct {
+type bnode[K any] struct {
 	keys     []K
 	children []*bnode[K]
 	isLeaf   bool
 }
 
-func newBNode[K cmp.Ordered](t int, leaf bool) *bnode[K] {
+func newBNode[K any](t int, leaf bool) *bnode[K] {
 	return &bnode[K]{
 		keys:     make([]K, 0, 2*t-1),
 		children: make([]*bnode[K], 0, 2*t),
@@ -20,19 +20,21 @@ func newBNode[K cmp.Ordered](t int, leaf bool) *bnode[K] {
 }
 
 // btree is the unexported base structure used by BTreeSet and BTreeMap.
-type btree[K cmp.Ordered] struct {
+type btree[K any] struct {
 	root      *bnode[K]
 	minDegree int // t (minimum children = t, maximum = 2t)
 	size      int
+	less      comparator.Comparator[K]
 }
 
-func newBTree[K cmp.Ordered](minDegree int) *btree[K] {
+func newBTree[K any](minDegree int, less comparator.Comparator[K]) *btree[K] {
 	if minDegree < 2 {
 		minDegree = 2
 	}
 	return &btree[K]{
 		root:      newBNode[K](minDegree, true),
 		minDegree: minDegree,
+		less:      less,
 	}
 }
 
@@ -45,10 +47,10 @@ func (t *btree[K]) search(key K) (*bnode[K], int) {
 
 func (t *btree[K]) searchNode(x *bnode[K], key K) (*bnode[K], int) {
 	i := 0
-	for i < len(x.keys) && key > x.keys[i] {
+	for i < len(x.keys) && t.less(x.keys[i], key) {
 		i++
 	}
-	if i < len(x.keys) && key == x.keys[i] {
+	if i < len(x.keys) && !t.less(key, x.keys[i]) && !t.less(x.keys[i], key) {
 		return x, i
 	}
 	if x.isLeaf {
@@ -76,14 +78,13 @@ func (t *btree[K]) insert(key K) bool {
 func (t *btree[K]) insertNonFull(x *bnode[K], key K) bool {
 	i := len(x.keys) - 1
 	if x.isLeaf {
-		// Detect duplicates.
 		for j := 0; j < len(x.keys); j++ {
-			if x.keys[j] == key {
+			if !t.less(x.keys[j], key) && !t.less(key, x.keys[j]) {
 				return false
 			}
 		}
 		x.keys = append(x.keys, key) // placeholder slot
-		for i >= 0 && key < x.keys[i] {
+		for i >= 0 && t.less(key, x.keys[i]) {
 			x.keys[i+1] = x.keys[i]
 			i--
 		}
@@ -91,13 +92,13 @@ func (t *btree[K]) insertNonFull(x *bnode[K], key K) bool {
 		t.size++
 		return true
 	}
-	for i >= 0 && key < x.keys[i] {
+	for i >= 0 && t.less(key, x.keys[i]) {
 		i--
 	}
 	i++
 	if len(x.children[i].keys) == 2*t.minDegree-1 {
 		t.splitChild(x, i)
-		if key > x.keys[i] {
+		if t.less(x.keys[i], key) {
 			i++
 		}
 	}
@@ -105,7 +106,7 @@ func (t *btree[K]) insertNonFull(x *bnode[K], key K) bool {
 }
 
 func (t *btree[K]) splitChild(parent *bnode[K], i int) {
-	degree := t.minDegree // do not shadow the receiver
+	degree := t.minDegree
 	y := parent.children[i]
 	z := newBNode[K](degree, y.isLeaf)
 
@@ -177,11 +178,11 @@ func (t *btree[K]) delete(key K) bool {
 func (t *btree[K]) deleteFromNode(x *bnode[K], key K) bool {
 	degree := t.minDegree
 	i := 0
-	for i < len(x.keys) && key > x.keys[i] {
+	for i < len(x.keys) && t.less(x.keys[i], key) {
 		i++
 	}
 	// Case 1: the key is in x.
-	if i < len(x.keys) && key == x.keys[i] {
+	if i < len(x.keys) && !t.less(key, x.keys[i]) && !t.less(x.keys[i], key) {
 		if x.isLeaf {
 			// Simple leaf removal.
 			x.keys = append(x.keys[:i], x.keys[i+1:]...)

--- a/pkg/tree/btree_iterator.go
+++ b/pkg/tree/btree_iterator.go
@@ -1,9 +1,7 @@
 package tree
 
-import "cmp"
-
 // BTreeIterator iterates over keys in ascending order.
-type BTreeIterator[K cmp.Ordered] struct {
+type BTreeIterator[K any] struct {
 	tree     *btree[K]
 	node     *bnode[K]
 	idx      int
@@ -12,7 +10,7 @@ type BTreeIterator[K cmp.Ordered] struct {
 }
 
 // newBTreeIterator creates an iterator positioned on the smallest element.
-func newBTreeIterator[K cmp.Ordered](tree *btree[K]) *BTreeIterator[K] {
+func newBTreeIterator[K any](tree *btree[K]) *BTreeIterator[K] {
 	it := &BTreeIterator[K]{tree: tree}
 	if tree.size == 0 {
 		it.finished = true
@@ -29,7 +27,7 @@ func newBTreeIterator[K cmp.Ordered](tree *btree[K]) *BTreeIterator[K] {
 }
 
 // newBTreeIteratorFromKey creates an iterator positioned on the first element >= key.
-func newBTreeIteratorFromKey[K cmp.Ordered](tree *btree[K], key K) *BTreeIterator[K] {
+func newBTreeIteratorFromKey[K any](tree *btree[K], key K) *BTreeIterator[K] {
 	it := &BTreeIterator[K]{tree: tree}
 	if tree.size == 0 {
 		it.finished = true
@@ -38,10 +36,10 @@ func newBTreeIteratorFromKey[K cmp.Ordered](tree *btree[K], key K) *BTreeIterato
 	node := tree.root
 	for {
 		i := 0
-		for i < len(node.keys) && key > node.keys[i] {
+		for i < len(node.keys) && tree.less(node.keys[i], key) {
 			i++
 		}
-		if i < len(node.keys) && node.keys[i] >= key {
+		if i < len(node.keys) && !tree.less(node.keys[i], key) {
 			// We may still find a smaller-but-valid key in the left subtree;
 			// descend to the leaf while preserving the position.
 			if node.isLeaf {
@@ -119,9 +117,6 @@ func (it *BTreeIterator[K]) Next() (K, bool) {
 	return val, true
 }
 
-// Prev would mirror Next descending leftward; it is intentionally omitted.
-// Range queries are exposed through Range below, which returns a slice.
-
 // Range returns a slice with all keys in the closed interval [low, high].
 func (t *btree[K]) Range(low, high K) []K {
 	result := []K{}
@@ -134,10 +129,10 @@ func (t *btree[K]) rangeTraverse(x *bnode[K], low, high K, result *[]K) {
 		return
 	}
 	i := 0
-	for i < len(x.keys) && x.keys[i] < low {
+	for i < len(x.keys) && t.less(x.keys[i], low) {
 		i++
 	}
-	for i < len(x.keys) && x.keys[i] <= high {
+	for i < len(x.keys) && !t.less(high, x.keys[i]) {
 		if !x.isLeaf {
 			t.rangeTraverse(x.children[i], low, high, result)
 		}

--- a/pkg/tree/btree_iterator_test.go
+++ b/pkg/tree/btree_iterator_test.go
@@ -3,12 +3,14 @@ package tree
 import (
 	"slices"
 	"testing"
+
+	"github.com/halissontorres/go-bag/pkg/comparator"
 )
 
 func TestBTreeIterator_EmptyTree(t *testing.T) {
 	t.Parallel()
 
-	s := NewBTreeSet[int]()
+	s := NewBTreeSet(comparator.Natural[int]())
 	it := s.Iterator()
 	if _, ok := it.Next(); ok {
 		t.Fatalf("Next on empty iterator should return false")
@@ -18,7 +20,7 @@ func TestBTreeIterator_EmptyTree(t *testing.T) {
 func TestBTreeIterator_InOrderTraversal(t *testing.T) {
 	t.Parallel()
 
-	s := NewBTreeSet[int](WithMinDegree(3))
+	s := NewBTreeSet(comparator.Natural[int](), WithMinDegree(3))
 	values := []int{50, 10, 80, 30, 20, 60, 90, 40, 70, 5, 15, 25, 35, 45, 55, 65, 75, 85, 95}
 	for _, v := range values {
 		s.Add(v)
@@ -43,7 +45,7 @@ func TestBTreeIterator_InOrderTraversal(t *testing.T) {
 func TestBTreeIterator_FromKey(t *testing.T) {
 	t.Parallel()
 
-	s := NewBTreeSet[int](WithMinDegree(3))
+	s := NewBTreeSet(comparator.Natural[int](), WithMinDegree(3))
 	for _, v := range []int{10, 20, 30, 40, 50, 60, 70, 80, 90} {
 		s.Add(v)
 	}
@@ -61,14 +63,12 @@ func TestBTreeIterator_FromKey(t *testing.T) {
 		t.Fatalf("IteratorFrom(35)=%v want %v", got, want)
 	}
 
-	// IteratorFrom past the max must yield no results.
 	tail := s.IteratorFrom(1000)
 	if _, ok := tail.Next(); ok {
 		t.Fatalf("IteratorFrom past max should be empty")
 	}
 
-	// IteratorFrom on an empty tree should be empty.
-	empty := NewBTreeSet[int]()
+	empty := NewBTreeSet(comparator.Natural[int]())
 	if _, ok := empty.IteratorFrom(0).Next(); ok {
 		t.Fatalf("IteratorFrom on empty should be empty")
 	}
@@ -77,7 +77,7 @@ func TestBTreeIterator_FromKey(t *testing.T) {
 func TestBTreeRange_Boundaries(t *testing.T) {
 	t.Parallel()
 
-	s := NewBTreeSet[int]()
+	s := NewBTreeSet(comparator.Natural[int]())
 	for _, v := range []int{1, 3, 5, 7, 9} {
 		s.Add(v)
 	}

--- a/pkg/tree/btreemap.go
+++ b/pkg/tree/btreemap.go
@@ -1,9 +1,9 @@
 package tree
 
-import "cmp"
+import "github.com/halissontorres/go-bag/pkg/comparator"
 
 // BTreeMap is a key-ordered map backed by a B-Tree.
-type BTreeMap[K cmp.Ordered, V any] struct {
+type BTreeMap[K comparable, V any] struct {
 	tree *btree[K]
 	vals map[K]V
 }
@@ -14,36 +14,41 @@ type KeyValuePair[K any, V any] struct {
 	Value V
 }
 
-func NewBTreeMap[K cmp.Ordered, V any](opts ...Option) *BTreeMap[K, V] {
+// NewBTreeMap creates a BTreeMap ordered by the provided Comparator.
+func NewBTreeMap[K comparable, V any](cmp comparator.Comparator[K], opts ...Option) *BTreeMap[K, V] {
 	c := applyTreeOptions(opts)
 	return &BTreeMap[K, V]{
-		tree: newBTree[K](c.minDegree),
+		tree: newBTree[K](c.minDegree, cmp),
 		vals: make(map[K]V),
 	}
 }
 
 func (m *BTreeMap[K, V]) Put(key K, value V) {
-	if m.tree.insert(key) {
-		m.vals[key] = value
-	} else {
-		m.vals[key] = value
+	if node, idx := m.tree.search(key); node != nil {
+		oldKey := node.keys[idx]
+		m.tree.delete(oldKey)
+		delete(m.vals, oldKey)
 	}
+	m.tree.insert(key)
+	m.vals[key] = value
 }
 
 func (m *BTreeMap[K, V]) Get(key K) (V, bool) {
-	if node, _ := m.tree.search(key); node != nil {
-		return m.vals[key], true
+	if node, idx := m.tree.search(key); node != nil {
+		return m.vals[node.keys[idx]], true
 	}
 	var zero V
 	return zero, false
 }
 
 func (m *BTreeMap[K, V]) Remove(key K) bool {
-	if !m.Contains(key) {
+	node, idx := m.tree.search(key)
+	if node == nil {
 		return false
 	}
-	delete(m.vals, key)
-	return m.tree.delete(key)
+	actualKey := node.keys[idx]
+	delete(m.vals, actualKey)
+	return m.tree.delete(actualKey)
 }
 
 func (m *BTreeMap[K, V]) Contains(key K) bool {

--- a/pkg/tree/btreemap_test.go
+++ b/pkg/tree/btreemap_test.go
@@ -3,12 +3,14 @@ package tree
 import (
 	"slices"
 	"testing"
+
+	"github.com/halissontorres/go-bag/pkg/comparator"
 )
 
 func TestBTreeMap_PutGetRemove(t *testing.T) {
 	t.Parallel()
 
-	m := NewBTreeMap[string, int]()
+	m := NewBTreeMap[string, int](comparator.Natural[string]())
 	if got, _ := m.Get("missing"); got != 0 {
 		t.Fatalf("Get on empty should return zero value, got %d", got)
 	}
@@ -42,7 +44,7 @@ func TestBTreeMap_PutGetRemove(t *testing.T) {
 func TestBTreeMap_KeysValuesSorted(t *testing.T) {
 	t.Parallel()
 
-	m := NewBTreeMap[int, string]()
+	m := NewBTreeMap[int, string](comparator.Natural[int]())
 	pairs := []KeyValuePair[int, string]{
 		{3, "three"}, {1, "one"}, {4, "four"}, {1, "one-dup"}, {5, "five"}, {9, "nine"}, {2, "two"}, {6, "six"},
 	}
@@ -75,7 +77,7 @@ func TestBTreeMap_KeysValuesSorted(t *testing.T) {
 func TestBTreeMap_MinMaxRange(t *testing.T) {
 	t.Parallel()
 
-	m := NewBTreeMap[int, string]()
+	m := NewBTreeMap[int, string](comparator.Natural[int]())
 	for _, k := range []int{10, 20, 5, 15, 25, 30, 8} {
 		m.Put(k, "v")
 	}
@@ -95,7 +97,7 @@ func TestBTreeMap_MinMaxRange(t *testing.T) {
 		t.Fatalf("Range keys=%v want %v", gotKeys, want)
 	}
 
-	empty := NewBTreeMap[int, string]()
+	empty := NewBTreeMap[int, string](comparator.Natural[int]())
 	if _, _, ok := empty.Min(); ok {
 		t.Fatalf("Min on empty should be false")
 	}
@@ -107,9 +109,8 @@ func TestBTreeMap_MinMaxRange(t *testing.T) {
 func TestBTreeMap_WithMinDegree(t *testing.T) {
 	t.Parallel()
 
-	// Default degree and WithMinDegree(2) must produce identical key order.
-	m1 := NewBTreeMap[int, string]()
-	m2 := NewBTreeMap[int, string](WithMinDegree(2))
+	m1 := NewBTreeMap[int, string](comparator.Natural[int]())
+	m2 := NewBTreeMap[int, string](comparator.Natural[int](), WithMinDegree(2))
 	for i := 0; i < 50; i++ {
 		m1.Put(i, "v")
 		m2.Put(i, "v")
@@ -118,8 +119,7 @@ func TestBTreeMap_WithMinDegree(t *testing.T) {
 		t.Fatal("default degree and WithMinDegree(2) should produce identical key order")
 	}
 
-	// Values below 2 are ignored; map falls back to default.
-	m3 := NewBTreeMap[int, string](WithMinDegree(1))
+	m3 := NewBTreeMap[int, string](comparator.Natural[int](), WithMinDegree(1))
 	for i := 0; i < 30; i++ {
 		m3.Put(i, "x")
 	}
@@ -127,8 +127,7 @@ func TestBTreeMap_WithMinDegree(t *testing.T) {
 		t.Fatalf("len=%d want 30", m3.Len())
 	}
 
-	// Higher degree (t=4) still maintains sorted key invariant.
-	m4 := NewBTreeMap[int, int](WithMinDegree(4))
+	m4 := NewBTreeMap[int, int](comparator.Natural[int](), WithMinDegree(4))
 	const N = 200
 	for i := N - 1; i >= 0; i-- {
 		m4.Put(i, i*2)
@@ -141,11 +140,56 @@ func TestBTreeMap_WithMinDegree(t *testing.T) {
 	}
 }
 
-// ---------- Benchmarks ----------
+type item struct {
+	ID   int
+	Name string
+}
+
+func TestBTreeMap_StructKeyByField(t *testing.T) {
+	byID := comparator.ByField(func(i item) int { return i.ID })
+	m := NewBTreeMap[item, string](byID)
+
+	m.Put(item{ID: 3, Name: "C"}, "third")
+	m.Put(item{ID: 1, Name: "A"}, "first")
+	m.Put(item{ID: 2, Name: "B"}, "second")
+
+	keys := m.Keys()
+	if keys[0].ID != 1 || keys[1].ID != 2 || keys[2].ID != 3 {
+		t.Fatalf("Keys not sorted by ID: %v", keys)
+	}
+
+	v, ok := m.Get(item{ID: 1})
+	if !ok || v != "first" {
+		t.Fatalf("Get({1})=%q,%v want first,true", v, ok)
+	}
+}
+
+func TestBTreeMap_StructKeyMultiCriterion(t *testing.T) {
+	byName := comparator.ByField(func(i item) string { return i.Name })
+	byID := comparator.ByField(func(i item) int { return i.ID })
+	cmp := byName.Then(byID)
+
+	m := NewBTreeMap[item, string](cmp)
+
+	m.Put(item{ID: 2, Name: "Alice"}, "a2")
+	m.Put(item{ID: 1, Name: "Alice"}, "a1")
+	m.Put(item{ID: 3, Name: "Bob"}, "b3")
+
+	keys := m.Keys()
+	if keys[0].Name != "Alice" || keys[0].ID != 1 {
+		t.Fatalf("first should be Alice/1, got %v", keys[0])
+	}
+	if keys[1].Name != "Alice" || keys[1].ID != 2 {
+		t.Fatalf("second should be Alice/2, got %v", keys[1])
+	}
+	if keys[2].Name != "Bob" || keys[2].ID != 3 {
+		t.Fatalf("third should be Bob/3, got %v", keys[2])
+	}
+}
 
 func BenchmarkBTreeMap_Put(b *testing.B) {
 	b.ReportAllocs()
-	m := NewBTreeMap[int, int]()
+	m := NewBTreeMap[int, int](comparator.Natural[int]())
 	i := 0
 	for b.Loop() {
 		m.Put(i, i)
@@ -155,7 +199,7 @@ func BenchmarkBTreeMap_Put(b *testing.B) {
 
 func BenchmarkBTreeMap_Get(b *testing.B) {
 	const N = 10_000
-	m := NewBTreeMap[int, int]()
+	m := NewBTreeMap[int, int](comparator.Natural[int]())
 	for i := 0; i < N; i++ {
 		m.Put(i, i)
 	}

--- a/pkg/tree/btreeset.go
+++ b/pkg/tree/btreeset.go
@@ -1,16 +1,16 @@
 package tree
 
-import "cmp"
+import "github.com/halissontorres/go-bag/pkg/comparator"
 
 // BTreeSet is an ordered set backed by a B-Tree.
-// Elements must satisfy the Ordered constraint (i.e. support <).
-type BTreeSet[T cmp.Ordered] struct {
+type BTreeSet[T any] struct {
 	tree *btree[T]
 }
 
-func NewBTreeSet[T cmp.Ordered](opts ...Option) *BTreeSet[T] {
+// NewBTreeSet creates a BTreeSet ordered by the provided Comparator.
+func NewBTreeSet[T any](cmp comparator.Comparator[T], opts ...Option) *BTreeSet[T] {
 	c := applyTreeOptions(opts)
-	return &BTreeSet[T]{tree: newBTree[T](c.minDegree)}
+	return &BTreeSet[T]{tree: newBTree[T](c.minDegree, cmp)}
 }
 
 func (s *BTreeSet[T]) Add(value T) bool {
@@ -23,7 +23,6 @@ func (s *BTreeSet[T]) Contains(value T) bool {
 }
 
 func (s *BTreeSet[T]) Remove(value T) bool {
-	// Simple implementation: rebuild the tree without the value.
 	if !s.Contains(value) {
 		return false
 	}
@@ -31,7 +30,7 @@ func (s *BTreeSet[T]) Remove(value T) bool {
 	s.Clear()
 	removed := false
 	for _, item := range items {
-		if item == value && !removed {
+		if !s.tree.less(item, value) && !s.tree.less(value, item) && !removed {
 			removed = true
 			continue
 		}
@@ -42,7 +41,7 @@ func (s *BTreeSet[T]) Remove(value T) bool {
 
 func (s *BTreeSet[T]) Len() int          { return s.tree.Len() }
 func (s *BTreeSet[T]) IsEmpty() bool     { return s.Len() == 0 }
-func (s *BTreeSet[T]) Clear()            { s.tree = newBTree[T](s.tree.minDegree) }
+func (s *BTreeSet[T]) Clear()            { s.tree = newBTree[T](s.tree.minDegree, s.tree.less) }
 func (s *BTreeSet[T]) ForEach(f func(T)) { s.tree.traverse(f) }
 func (s *BTreeSet[T]) Elements() []T {
 	var result []T

--- a/pkg/tree/btreeset_test.go
+++ b/pkg/tree/btreeset_test.go
@@ -4,12 +4,14 @@ import (
 	"math/rand/v2"
 	"slices"
 	"testing"
+
+	"github.com/halissontorres/go-bag/pkg/comparator"
 )
 
 func TestBTreeSet_AddContainsRemove(t *testing.T) {
 	t.Parallel()
 
-	s := NewBTreeSet[int]()
+	s := NewBTreeSet(comparator.Natural[int]())
 	if !s.IsEmpty() {
 		t.Fatalf("expected empty set")
 	}
@@ -19,7 +21,6 @@ func TestBTreeSet_AddContainsRemove(t *testing.T) {
 			t.Fatalf("Add(%d) should be true", v)
 		}
 	}
-	// Adding a duplicate must be a no-op.
 	if s.Add(10) {
 		t.Fatalf("Add(10) duplicate should return false")
 	}
@@ -35,7 +36,6 @@ func TestBTreeSet_AddContainsRemove(t *testing.T) {
 		t.Fatalf("should not contain 999")
 	}
 
-	// Inorder traversal must be sorted.
 	got := s.Elements()
 	want := slices.Clone(values)
 	slices.Sort(want)
@@ -47,12 +47,11 @@ func TestBTreeSet_AddContainsRemove(t *testing.T) {
 func TestBTreeSet_RemoveAcrossSplits(t *testing.T) {
 	t.Parallel()
 
-	s := NewBTreeSet[int](WithMinDegree(3))
+	s := NewBTreeSet(comparator.Natural[int](), WithMinDegree(3))
 	const N = 200
 	for i := 0; i < N; i++ {
 		s.Add(i)
 	}
-	// Remove every other element and check ordering and length invariants.
 	for i := 0; i < N; i += 2 {
 		if !s.Remove(i) {
 			t.Fatalf("Remove(%d) should return true", i)
@@ -77,7 +76,7 @@ func TestBTreeSet_RemoveAcrossSplits(t *testing.T) {
 func TestBTreeSet_MinMaxRange(t *testing.T) {
 	t.Parallel()
 
-	s := NewBTreeSet[int]()
+	s := NewBTreeSet(comparator.Natural[int]())
 	for _, v := range []int{50, 10, 80, 30, 20, 60, 90, 40, 70} {
 		s.Add(v)
 	}
@@ -91,7 +90,7 @@ func TestBTreeSet_MinMaxRange(t *testing.T) {
 		t.Fatalf("Range=%v want %v", got, want)
 	}
 
-	empty := NewBTreeSet[int]()
+	empty := NewBTreeSet(comparator.Natural[int]())
 	if _, ok := empty.Min(); ok {
 		t.Fatalf("Min on empty should be false")
 	}
@@ -106,7 +105,7 @@ func TestBTreeSet_MinMaxRange(t *testing.T) {
 func TestBTreeSet_Clear(t *testing.T) {
 	t.Parallel()
 
-	s := NewBTreeSet[int]()
+	s := NewBTreeSet(comparator.Natural[int]())
 	for i := 0; i < 50; i++ {
 		s.Add(i)
 	}
@@ -124,7 +123,7 @@ func TestBTreeSet_RandomizedAgainstSlice(t *testing.T) {
 	t.Parallel()
 
 	r := rand.New(rand.NewPCG(42, 99))
-	s := NewBTreeSet[int](WithMinDegree(3))
+	s := NewBTreeSet(comparator.Natural[int](), WithMinDegree(3))
 	ref := make(map[int]struct{})
 	const ops = 5_000
 
@@ -156,7 +155,6 @@ func TestBTreeSet_RandomizedAgainstSlice(t *testing.T) {
 			t.Fatalf("set should contain %d", k)
 		}
 	}
-	// In-order traversal must be sorted.
 	got := s.Elements()
 	if !slices.IsSorted(got) {
 		t.Fatalf("Elements not sorted")
@@ -166,9 +164,8 @@ func TestBTreeSet_RandomizedAgainstSlice(t *testing.T) {
 func TestBTreeSet_WithMinDegree(t *testing.T) {
 	t.Parallel()
 
-	// Default degree (2) must work the same as explicit WithMinDegree(2).
-	s1 := NewBTreeSet[int]()
-	s2 := NewBTreeSet[int](WithMinDegree(2))
+	s1 := NewBTreeSet(comparator.Natural[int]())
+	s2 := NewBTreeSet(comparator.Natural[int](), WithMinDegree(2))
 	for i := 0; i < 100; i++ {
 		s1.Add(i)
 		s2.Add(i)
@@ -177,8 +174,7 @@ func TestBTreeSet_WithMinDegree(t *testing.T) {
 		t.Fatal("default degree and WithMinDegree(2) should produce identical results")
 	}
 
-	// Values below 2 are ignored; tree falls back to default.
-	s3 := NewBTreeSet[int](WithMinDegree(0))
+	s3 := NewBTreeSet(comparator.Natural[int](), WithMinDegree(0))
 	for i := 0; i < 50; i++ {
 		s3.Add(i)
 	}
@@ -186,8 +182,7 @@ func TestBTreeSet_WithMinDegree(t *testing.T) {
 		t.Fatalf("len=%d want 50", s3.Len())
 	}
 
-	// Higher degree (t=5) still maintains sorted invariant.
-	s4 := NewBTreeSet[int](WithMinDegree(5))
+	s4 := NewBTreeSet(comparator.Natural[int](), WithMinDegree(5))
 	const N = 300
 	for i := N - 1; i >= 0; i-- {
 		s4.Add(i)
@@ -200,11 +195,47 @@ func TestBTreeSet_WithMinDegree(t *testing.T) {
 	}
 }
 
-// ---------- Benchmarks ----------
+type person struct {
+	Name string
+	Age  int
+}
+
+func TestBTreeSet_StructByField(t *testing.T) {
+	s := NewBTreeSet(comparator.ByField(func(p person) int { return p.Age }))
+
+	s.Add(person{Name: "Alice", Age: 30})
+	s.Add(person{Name: "Bob", Age: 25})
+	s.Add(person{Name: "Charlie", Age: 35})
+
+	elements := s.Elements()
+	if elements[0].Age != 25 || elements[1].Age != 30 || elements[2].Age != 35 {
+		t.Fatalf("Elements not sorted by age: %v", elements)
+	}
+}
+
+func TestBTreeSet_StructMultiCriterion(t *testing.T) {
+	byAge := comparator.ByField(func(p person) int { return p.Age })
+	byName := comparator.ByField(func(p person) string { return p.Name })
+	cmp := byAge.Then(byName)
+
+	s := NewBTreeSet(cmp)
+
+	s.Add(person{Name: "Charlie", Age: 30})
+	s.Add(person{Name: "Alice", Age: 30})
+	s.Add(person{Name: "Bob", Age: 25})
+
+	elements := s.Elements()
+	if elements[0].Name != "Bob" {
+		t.Fatalf("first should be Bob (age 25), got %v", elements[0])
+	}
+	if elements[1].Name != "Alice" || elements[2].Name != "Charlie" {
+		t.Fatalf("ages 30 should be ordered by name: Alice then Charlie; got %v, %v", elements[1], elements[2])
+	}
+}
 
 func BenchmarkBTreeSet_Add(b *testing.B) {
 	b.ReportAllocs()
-	s := NewBTreeSet[int]()
+	s := NewBTreeSet(comparator.Natural[int]())
 	i := 0
 	for b.Loop() {
 		s.Add(i)
@@ -214,7 +245,7 @@ func BenchmarkBTreeSet_Add(b *testing.B) {
 
 func BenchmarkBTreeSet_Contains(b *testing.B) {
 	const N = 10_000
-	s := NewBTreeSet[int]()
+	s := NewBTreeSet(comparator.Natural[int]())
 	for i := 0; i < N; i++ {
 		s.Add(i)
 	}
@@ -229,7 +260,7 @@ func BenchmarkBTreeSet_Contains(b *testing.B) {
 
 func BenchmarkBTreeSet_Range(b *testing.B) {
 	const N = 10_000
-	s := NewBTreeSet[int]()
+	s := NewBTreeSet(comparator.Natural[int]())
 	for i := 0; i < N; i++ {
 		s.Add(i)
 	}


### PR DESCRIPTION
Summary

Closes  #3 

  - Adds pkg/comparator with a Comparator[T any] type and built-in helpers (Natural, Reverse, ByField, Then)
  - Refactors Heap, BTreeSet, BTreeMap, and Stream.Sorted to accept a Comparator instead of constraining T to cmp.Ordered
  - Enables ordering of any type — structs by field, external types like time.Time, multi-criterion sorts via chaining
  - Updates all tests and README examples for the new API

  Why

  cmp.Ordered only covers built-in numeric and string types. Custom structs, time.Time, and other domain types couldn't be used with ordered collections. The Comparator
  abstraction makes every ordered collection work with any type, from trivial Natural[int]() to ByField(...).Then(ByField(...)).

  Changes by package

  pkg/comparator (new) — Comparator[T any] func(a, b T) bool with Natural, Reverse, ByField, and chaining via Then.

  pkg/heap — Heap[T any], SyncHeap[T any]. Constructor takes a mandatory Comparator (e.g. heap.New(comparator.Natural[int]())). Removed
  WithMinHeap/WithMaxHeap/WithLessFunc; added WithComparator.

  pkg/tree — BTreeSet[T any], BTreeMap[K comparable, V any]. All 15+ internal </>/== comparisons replaced with less() calls. Put/Get/Remove use the actual stored btree key
   for map operations, correctly handling cases where comparator-equal keys differ by Go ==.

  pkg/stream — Replaced Sorted[T cmp.Ordered] with SortedBy[T any]. Added DistinctBy[T any] for comparator-based deduplication. Distinct[T comparable] is preserved.

  README.md — All Heap, BTreeSet, BTreeMap, and Stream examples updated. New "Custom ordering with Comparator" section with struct, multi-criterion, and external-type
  examples.

  No breaking changes to unaffected packages